### PR TITLE
Units page action loading

### DIFF
--- a/app/(main)/units/my-courses.tsx
+++ b/app/(main)/units/my-courses.tsx
@@ -85,6 +85,7 @@ function OwnedCourseCard({
   >(null);
   const isPublic = course.visibility === "public";
   const isLocked = isPublic && !isAdmin;
+  const isActionPending = isPending || activeAction !== null;
 
   function handleMakePublic() {
     const confirmed = window.confirm(
@@ -95,8 +96,8 @@ function OwnedCourseCard({
     );
     if (!confirmed) return;
 
+    setActiveAction("make-public");
     startTransition(async () => {
-      setActiveAction("make-public");
       try {
         const result = await makeCoursePublic(course.id);
         if (result.success) {
@@ -111,8 +112,8 @@ function OwnedCourseCard({
   }
 
   function handleMakePrivate() {
+    setActiveAction("make-private");
     startTransition(async () => {
-      setActiveAction("make-private");
       try {
         const result = await makeCoursePrivate(course.id);
         if (result.success) {
@@ -134,8 +135,8 @@ function OwnedCourseCard({
     );
     if (!confirmed) return;
 
+    setActiveAction("delete");
     startTransition(async () => {
-      setActiveAction("delete");
       try {
         const result = await deleteCourse(course.id);
         if (result.success) {
@@ -236,10 +237,10 @@ function OwnedCourseCard({
         {!isPublic && (
           <button
             onClick={handleMakePublic}
-            disabled={isPending}
+            disabled={isActionPending}
             className="inline-flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-xs font-bold text-lingo-green hover:bg-lingo-green/10 transition-colors disabled:opacity-50"
           >
-            {isPending && activeAction === "make-public" ? (
+            {activeAction === "make-public" ? (
               <>
                 <span className="h-3.5 w-3.5 animate-spin rounded-full border-2 border-lingo-green/30 border-t-lingo-green" />
                 Making Public...
@@ -269,10 +270,10 @@ function OwnedCourseCard({
         {isAdmin && isPublic && (
           <button
             onClick={handleMakePrivate}
-            disabled={isPending}
+            disabled={isActionPending}
             className="inline-flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-xs font-bold text-red-500 hover:bg-red-50 transition-colors disabled:opacity-50"
           >
-            {isPending && activeAction === "make-private" ? (
+            {activeAction === "make-private" ? (
               <>
                 <span className="h-3.5 w-3.5 animate-spin rounded-full border-2 border-red-500/30 border-t-red-500" />
                 Making Private...
@@ -301,10 +302,10 @@ function OwnedCourseCard({
         {!isLocked && (
           <button
             onClick={handleDelete}
-            disabled={isPending}
+            disabled={isActionPending}
             className="inline-flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-xs font-bold text-red-500 hover:bg-red-50 transition-colors disabled:opacity-50"
           >
-            {isPending && activeAction === "delete" ? (
+            {activeAction === "delete" ? (
               <>
                 <span className="h-3.5 w-3.5 animate-spin rounded-full border-2 border-red-500/30 border-t-red-500" />
                 Deleting...

--- a/app/(main)/units/standalone-units.tsx
+++ b/app/(main)/units/standalone-units.tsx
@@ -58,6 +58,7 @@ function StandaloneUnitCard({
   const hasParseError = unit.parseError === true;
 
   const isEditLocked = isPublic && !isAdmin;
+  const isActionPending = isPending || activeAction !== null;
 
   function handleMakePublic() {
     const confirmed = window.confirm(
@@ -68,8 +69,8 @@ function StandaloneUnitCard({
     );
     if (!confirmed) return;
 
+    setActiveAction("make-public");
     startTransition(async () => {
-      setActiveAction("make-public");
       try {
         const result = await makeUnitPublic(unit.id);
         if (result.success) {
@@ -84,8 +85,8 @@ function StandaloneUnitCard({
   }
 
   function handleMakePrivate() {
+    setActiveAction("make-private");
     startTransition(async () => {
-      setActiveAction("make-private");
       try {
         const result = await makeUnitPrivate(unit.id);
         if (result.success) {
@@ -100,8 +101,8 @@ function StandaloneUnitCard({
   }
 
   function handleRemoveFromLibrary() {
+    setActiveAction("remove");
     startTransition(async () => {
-      setActiveAction("remove");
       try {
         const result = await removeUnitFromLibrary(unit.id);
         if (result.success) {
@@ -122,8 +123,8 @@ function StandaloneUnitCard({
     );
     if (!confirmed) return;
 
+    setActiveAction("delete");
     startTransition(async () => {
-      setActiveAction("delete");
       try {
         const result = await deleteUnit(unit.id);
         if (result.success) {
@@ -264,10 +265,10 @@ function StandaloneUnitCard({
               {!isPublic && (
                 <button
                   onClick={handleMakePublic}
-                  disabled={isPending}
+                  disabled={isActionPending}
                   className="inline-flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-xs font-bold text-lingo-green hover:bg-lingo-green/10 transition-colors disabled:opacity-50"
                 >
-                  {isPending && activeAction === "make-public" ? (
+                  {activeAction === "make-public" ? (
                     <>
                       <span className="h-3.5 w-3.5 animate-spin rounded-full border-2 border-lingo-green/30 border-t-lingo-green" />
                       Making Public...
@@ -295,10 +296,10 @@ function StandaloneUnitCard({
               {!isEditLocked && (
                 <button
                   onClick={handleDelete}
-                  disabled={isPending}
+                  disabled={isActionPending}
                   className="inline-flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-xs font-bold text-red-500 hover:bg-red-50 transition-colors disabled:opacity-50"
                 >
-                  {isPending && activeAction === "delete" ? (
+                  {activeAction === "delete" ? (
                     <>
                       <span className="h-3.5 w-3.5 animate-spin rounded-full border-2 border-red-500/30 border-t-red-500" />
                       Deleting...
@@ -335,10 +336,10 @@ function StandaloneUnitCard({
           {isAdmin && isPublic && (
             <button
               onClick={handleMakePrivate}
-              disabled={isPending}
+              disabled={isActionPending}
               className="inline-flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-xs font-bold text-red-500 hover:bg-red-50 transition-colors disabled:opacity-50"
             >
-              {isPending && activeAction === "make-private" ? (
+              {activeAction === "make-private" ? (
                 <>
                   <span className="h-3.5 w-3.5 animate-spin rounded-full border-2 border-red-500/30 border-t-red-500" />
                   Making Private...
@@ -367,7 +368,7 @@ function StandaloneUnitCard({
           {!unit.isOwner && unit.isInLibrary && (
             <button
               onClick={handleRemoveFromLibrary}
-              disabled={isPending}
+              disabled={isActionPending}
               className="inline-flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-xs font-bold text-lingo-text-light hover:bg-lingo-gray/50 transition-colors disabled:opacity-50"
             >
               <svg


### PR DESCRIPTION
Add loading spinners to "Make public", "Make private", and "Delete" buttons on the units page to provide immediate visual feedback when an action is in progress.

---
<p><a href="https://cursor.com/agents/bc-38dbd95b-1a01-49dc-890a-238b45412914"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-38dbd95b-1a01-49dc-890a-238b45412914"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

